### PR TITLE
changes to support setting track image

### DIFF
--- a/Libraries/Components/SliderIOS/SliderIOS.ios.js
+++ b/Libraries/Components/SliderIOS/SliderIOS.ios.js
@@ -79,6 +79,11 @@ var SliderIOS = React.createClass({
      * Default value is false.
      */
     disabled: PropTypes.bool,
+
+    /**
+     * Sets an image for the track. It only supports images that are included as assets
+     */
+    trackImage: PropTypes.string
   },
 
   getDefaultProps: function(): DefaultProps {
@@ -108,6 +113,7 @@ var SliderIOS = React.createClass({
         maximumTrackTintColor={this.props.maximumTrackTintColor}
         onChange={this._onValueChange}
         disabled={this.props.disabled}
+        trackImage={this.props.trackImage}
       />
     );
   }

--- a/React/Views/RCTSlider.m
+++ b/React/Views/RCTSlider.m
@@ -32,4 +32,16 @@
   super.value = _unclippedValue;
 }
 
+-(void)setTrackImage: (NSString *) trackImageSrc
+{
+
+  UIImage *sliderTrackImage = [UIImage imageNamed: trackImageSrc];
+  NSInteger width = sliderTrackImage.size.width;
+
+  UIImage *sliderLeftTrackImage = [sliderTrackImage resizableImageWithCapInsets:UIEdgeInsetsMake(0, width, 0, 0)];
+  UIImage *setMaximumTrackImage = [sliderTrackImage resizableImageWithCapInsets:UIEdgeInsetsMake(0, 0, 0, width)];
+
+  [super setMinimumTrackImage:sliderLeftTrackImage forState:UIControlStateNormal];
+  [super setMaximumTrackImage:setMaximumTrackImage forState:UIControlStateNormal];
+}
 @end

--- a/React/Views/RCTSliderManager.m
+++ b/React/Views/RCTSliderManager.m
@@ -49,6 +49,7 @@ static void RCTSendSliderEvent(RCTSlider *sender, BOOL continuous)
 }
 
 RCT_EXPORT_VIEW_PROPERTY(value, float);
+RCT_EXPORT_VIEW_PROPERTY(trackImage, NSString);
 RCT_EXPORT_VIEW_PROPERTY(minimumValue, float);
 RCT_EXPORT_VIEW_PROPERTY(maximumValue, float);
 RCT_EXPORT_VIEW_PROPERTY(minimumTrackTintColor, UIColor);


### PR DESCRIPTION
this change will allow the slider to have different track images.

to use it, set the property trackImage of sliderIOS with the name of an image that has been added as an asset in xcode