### PR TITLE
added method to set thumb image and size

### DIFF
--- a/Libraries/Components/SliderIOS/SliderIOS.ios.js
+++ b/Libraries/Components/SliderIOS/SliderIOS.ios.js
@@ -79,6 +79,12 @@ var SliderIOS = React.createClass({
      * Default value is false.
      */
     disabled: PropTypes.bool,
+
+    /**
+     * Sets an image for the thumb. It only supports images that are included as assets. It expects a dictionary that has the following form: {'source':'mySource','width':0,'height':0}
+     */
+    thumbImage: PropTypes.object
+
   },
 
   getDefaultProps: function(): DefaultProps {
@@ -108,6 +114,8 @@ var SliderIOS = React.createClass({
         maximumTrackTintColor={this.props.maximumTrackTintColor}
         onChange={this._onValueChange}
         disabled={this.props.disabled}
+        thumbImage={this.props.thumbImage}
+
       />
     );
   }

--- a/React/Views/RCTSlider.m
+++ b/React/Views/RCTSlider.m
@@ -32,4 +32,18 @@
   super.value = _unclippedValue;
 }
 
+- (void)setThumbImage:(NSDictionary *) thumbImage
+{
+  UIImage *image = [UIImage imageNamed:thumbImage[@"source"]];
+
+  CGSize newSize = CGSizeMake([thumbImage[@"width"] floatValue], [thumbImage[@"height"] floatValue]);
+  UIGraphicsBeginImageContextWithOptions(newSize, NO, 0.0);
+  [image drawInRect:CGRectMake(0, 0, newSize.width, newSize.height)];
+  UIImage *newImage = UIGraphicsGetImageFromCurrentImageContext();
+  UIGraphicsEndImageContext();
+
+
+  [super setThumbImage:newImage forState:UIControlStateNormal];
+}
+
 @end

--- a/React/Views/RCTSliderManager.m
+++ b/React/Views/RCTSliderManager.m
@@ -49,6 +49,7 @@ static void RCTSendSliderEvent(RCTSlider *sender, BOOL continuous)
 }
 
 RCT_EXPORT_VIEW_PROPERTY(value, float);
+RCT_EXPORT_VIEW_PROPERTY(thumbImage, NSDictionary);
 RCT_EXPORT_VIEW_PROPERTY(minimumValue, float);
 RCT_EXPORT_VIEW_PROPERTY(maximumValue, float);
 RCT_EXPORT_VIEW_PROPERTY(minimumTrackTintColor, UIColor);


### PR DESCRIPTION
this change will allow the slider to have different thumb images.

Sets an image for the thumb. It only supports images that are included as assets. It expects a dictionary that has the following form: {'source':'mySource','width':0,'height':0}
